### PR TITLE
fixed broken landing page due to missing controlelr

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,7 @@
+class GamesController < ApplicationController
+  skip_before_action :authenticate_user!, only: :index
+
+  def index
+    @games = Game.all
+  end
+end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="row">
+    <div class="col-6">
+      <h1>Checkout our games</h1>
+
+      <p>Woops, they are yet to be implemented.</p>
+    </div>
+  </div>
+</div>

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GamesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
We'll need this bare minimum fix to have a working landing page with our most recent route update. Otherwise prod would look like this
<img width="572" alt="Screen Shot 2022-02-12 at 23 27 52" src="https://user-images.githubusercontent.com/18746187/153715283-9609b306-9d12-4461-bad4-a2e9a60b3bef.png">

due to this error:
```ruby
2022-02-12T14:13:46.687304+00:00 app[web.1]: I, [2022-02-12T14:13:46.687224 #4]  INFO -- : [655e0160-8d8a-47f3-a021-36b8b2250fa5] Started GET "/" for 126.74.147.254 at 2022-02-12 14:13:46 +0000
2022-02-12T14:13:46.694078+00:00 app[web.1]: F, [2022-02-12T14:13:46.694014 #4] FATAL -- : [655e0160-8d8a-47f3-a021-36b8b2250fa5]
2022-02-12T14:13:46.694079+00:00 app[web.1]: [655e0160-8d8a-47f3-a021-36b8b2250fa5] ActionController::RoutingError (uninitialized constant GamesController
2022-02-12T14:13:46.694080+00:00 app[web.1]: Did you mean?  PagesController):
```
