### PR TITLE
added enum status for instances and minor cleanups

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -2,10 +2,10 @@ class InstancesController < ApplicationController
   def create # Create the game instance
     if user_signed_in?
       # Create an instance with current_user as host
+      # Instance default status will be "waiting"
       @instance = Instance.create!(
         game_id: params[:game_id],
-        user_id: current_user.id,
-        status: "pending"
+        user_id: current_user.id
       )
 
       # Make the host a player

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -3,4 +3,8 @@ class Instance < ApplicationRecord
   belongs_to :user # host
   has_many :players, dependent: :destroy
   has_many :player_inputs, dependent: :destroy
+
+  validates :status, presence: true, inclusion: { in: ['waiting', 'in progress', 'done'] }
+
+  enum status: { waiting: 'waiting', in_progress: 'in progress', done: 'done' }
 end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -4,7 +4,7 @@ class Instance < ApplicationRecord
   has_many :players, dependent: :destroy
   has_many :player_inputs, dependent: :destroy
 
-  validates :status, presence: true, inclusion: { in: ['waiting', 'in progress', 'done'] }
-
-  enum status: { waiting: 'waiting', in_progress: 'in progress', done: 'done' }
+  validates :status, presence: true, inclusion: { in: ['waiting', 'ongoing', 'done'] }
+  
+  enum status: { waiting: 'waiting', ongoing: 'ongoing', done: 'done' }
 end

--- a/db/migrate/20220213160445_add_default_value_to_instance_status.rb
+++ b/db/migrate/20220213160445_add_default_value_to_instance_status.rb
@@ -1,0 +1,8 @@
+class AddDefaultValueToInstanceStatus < ActiveRecord::Migration[6.0]
+  def change
+    # update column to have null: false
+    change_column_null :instances, :status, false
+    # update column to have default value for status as "waiting"
+    change_column_default :instances, :status, "waiting"
+  end
+end

--- a/test/models/games_content.rb
+++ b/test/models/games_content.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class GamesDatumTest < ActiveSupport::TestCase
+class GamesContent < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end


### PR DESCRIPTION
- Can now do these methods for instance status
<img width="895" alt="Screen Shot 2022-02-14 at 1 55 06" src="https://user-images.githubusercontent.com/18746187/153765735-40516705-dcee-4269-ad47-d01f7cff8d81.png">

- Instance status only accepts "waiting", "ongoing", or "done"
- Initially "ongoing" was supposed to be "in progress" but enums don't seem to like sapces :(