### PR TITLE
updated type and value column names to not clash with reserved keywords

### DIFF
--- a/db/migrate/20220216031820_chagne_column_names_in_player_inputs.rb
+++ b/db/migrate/20220216031820_chagne_column_names_in_player_inputs.rb
@@ -1,0 +1,6 @@
+class ChagneColumnNamesInPlayerInputs < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :player_inputs, :type, :input_type
+    rename_column :player_inputs, :value, :input_value
+  end
+end


### PR DESCRIPTION
As per [slack](https://lewagon-alumni.slack.com/archives/C02PHUR51V1/p1644970175146919), fixing name clash issues.