### PR TITLE
Added comments to websockets

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -8,7 +8,7 @@ class InstancesController < ApplicationController
       game_id: params[:game_id],
       user_id: current_user.id,
     )
-  
+
     # Simplistic pin number
     @instance.pin = 100_000 + @instance.id
     @instance.save
@@ -29,6 +29,11 @@ class InstancesController < ApplicationController
     @game = Game.find(@instance.game_id)
     @host = User.find(@instance.user_id)
     @players = Player.where(instance_id: @instance.id)
+
+    # To grab the list of players' names in the instance (Also includes the host name...)
+    @player_ids = @players.map(&:user_id)
+    @each_player_id = @player_ids.join(', ')
+    @each_player_name = @player_ids.map { |id| User.find(id).nickname }.join(', ')
   end
 
   def update # Update the status, pending -> ongoing -> completed

--- a/app/javascript/channels/instance_channel.js
+++ b/app/javascript/channels/instance_channel.js
@@ -3,17 +3,20 @@ import consumer from "./consumer";
 const initInstanceChannel = () => {
   const instanceContainer = document.getElementById("instance")
   if (instanceContainer) {
-    const id = instanceContainer.dataset.instanceId;
-    const player = instanceContainer.dataset.playerName
-    const playerId= instanceContainer.dataset.playerId;
+    const instance_id = instanceContainer.dataset.instanceId;
+    const host_id = instanceContainer.dataset.hostId;
+    const host_name = instanceContainer.dataset.hostName;
+    const player_id = instanceContainer.dataset.playerId
+    const player_name = instanceContainer.dataset.playerName
 
-    consumer.subscriptions.create({ channel: "InstanceChannel", id :id }, {
+    consumer.subscriptions.create({ channel: "InstanceChannel", id :instance_id }, {
       connected() {
-        console.log(`Welcome ${player}, id:${playerId} to Instance Channel ${id}`);
+        console.log(`PLAYER ID: ${player_id} HOST ID: ${host_id} PLAYER NAME: ${player_name} HOST NAME: ${host_name}`)
       },
 
       disconnected() {
         console.log("InstanceChannel disconnected");
+        `${player_name} has left the Instance Channel ${instance_id}`
       },
 
       received(data) {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,7 +24,8 @@ require("channels")
 
 // External imports
 import "bootstrap";
-import {initInstanceChannel} from '../channels/instance_channel'
+import { initInstanceChannel } from '../channels/instance_channel'
+
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';

--- a/app/views/instances/show.html.erb
+++ b/app/views/instances/show.html.erb
@@ -1,10 +1,8 @@
 
 <!-- Added data-player-name to see if player.username is being passed to JS-->
-<div id="instance" data-instance-id="<%=@instance.id%>" data-host-id="<%=@instance.user_id%>" data-host-name="<%=@instance.user.username%>">
+<div id="instance" data-instance-id="<%=@instance.id%>" data-host-id="<%=@instance.user_id%>" data-host-name="<%=@instance.user.username%>" data-player-name="<%=@each_player_name%>" data-player-id="<%=@each_player_id%>">
 
 <!-- Waiting page -->
   <%= render "instance_waiting_page", players: @players, instance: @instance  %>
 
 </div>
-
-


### PR DESCRIPTION
Check the console in Chrome for websocket comments.
I was able to grab the Player's Nickname and Player Id and display it in the console.

But a few problems: 

- Host's name can also be in the player's name list. Is that okay? Or do we want to change it so that it's only the players in the players' name list.
- If a player leaves, it does not console log that they have been disconnected. 
- There can be duplicates
- If the host leaves, the socket is still open. 

![image](https://user-images.githubusercontent.com/67456282/154292003-f07265e9-11af-4aa9-a7bf-718dfc386ce0.png)
![image](https://user-images.githubusercontent.com/67456282/154292542-7d460bc4-c8d3-469a-a60c-bce68aef6a19.png)
