### PR TITLE
Implemented the round logic

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -37,15 +37,5 @@ class InstancesController < ApplicationController
   end
 
   def update # Update the status, pending -> ongoing -> completed
-    @instance = Instance.find(params[:id])
-    @instance.status = "ongoing"
-    @game = Game.find(@instance.game_id)
-
-    if @instance.save
-      InstanceChannel.broadcast_to(
-        @instance,
-        render_to_string(partial: "instances/show_question", locals: { game: @game })
-      )
-    end
   end
 end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -5,10 +5,11 @@ class RoundsController < ApplicationController
     @instance.status = "ongoing"
 
     @game_content = GameContent.all.sample
-    rounds = Round.where(game_content_id: @game_content.id)
+    rounds = Round.where(instance_id: @instance.id)
     @round = Round.create!(
       number: rounds.count + 1,
-      game_content_id: @game_content.id
+      game_content_id: @game_content.id,
+      instance_id: @instance.id
     )
 
     if @instance.save

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -3,7 +3,7 @@ class RoundsController < ApplicationController
   def create
     @instance = Instance.find(params[:instance_id])
 
-    if @instance.status != "ongoing"
+    if @instance.status == "ongoing"
       @instance.status = "ongoing"
       @instance.save
     end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -2,17 +2,21 @@ class RoundsController < ApplicationController
   # Start creating a round after Start button or Next Question button has been clicked
   def create
     @instance = Instance.find(params[:instance_id])
-    @instance.status = "ongoing"
+
+    if @instance.status != "ongoing"
+      @instance.status = "ongoing"
+      @instance.save
+    end
 
     @game_content = GameContent.all.sample
     rounds = Round.where(instance_id: @instance.id)
-    @round = Round.create!(
+    @round = Round.new(
       number: rounds.count + 1,
       game_content_id: @game_content.id,
       instance_id: @instance.id
     )
 
-    if @instance.save
+    if @round.save
       InstanceChannel.broadcast_to(
         @instance,
         render_to_string(partial: "instances/show_question", locals: { game_content: @game_content, round: @round })

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -1,6 +1,21 @@
 class RoundsController < ApplicationController
-  # Start creating a round after Start button has been clicked
+  # Start creating a round after Start button or Next Question button has been clicked
   def create
-    
+    @instance = Instance.find(params[:instance_id])
+    @instance.status = "ongoing"
+
+    @game_content = GameContent.all.sample
+    rounds = Round.where(game_content_id: @game_content.id)
+    @round = Round.create!(
+      number: rounds.count + 1,
+      game_content_id: @game_content.id
+    )
+
+    if @instance.save
+      InstanceChannel.broadcast_to(
+        @instance,
+        render_to_string(partial: "instances/show_question", locals: { game_content: @game_content, round: @round })
+      )
+    end
   end
 end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -3,7 +3,7 @@ class RoundsController < ApplicationController
   def create
     @instance = Instance.find(params[:instance_id])
 
-    if @instance.status == "ongoing"
+    if @instance.status == "waiting"
       @instance.status = "ongoing"
       @instance.save
     end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -1,4 +1,5 @@
 class Round < ApplicationRecord
   # numericality is to only accept positive values
+  belongs_to :instance
   validates :number, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/instances/_show_question.erb
+++ b/app/views/instances/_show_question.erb
@@ -2,7 +2,7 @@
 <div class="container-fluid" style="height: 75vh;">
   <div class="d-flex justify-content-center align-items-center h-100">
     <div class="text-center">
-      <h5>Round <% round.number %></h5>
+      <h5>Round <%= round.number %></h5>
       <h3>Never Have I ever <%= game_content.content %></h3>
       <div class="p-4">
         <!-- "Yes" and "No" buttons here will be replaced -->

--- a/app/views/instances/_show_question.erb
+++ b/app/views/instances/_show_question.erb
@@ -2,7 +2,8 @@
 <div class="container-fluid" style="height: 75vh;">
   <div class="d-flex justify-content-center align-items-center h-100">
     <div class="text-center">
-      <h3>Never Have I ever <%= game.game_contents.sample.content %></h3>
+      <h5>Round <% round.number %></h5>
+      <h3>Never Have I ever <%= game_content.content %></h3>
       <div class="p-4">
         <!-- "Yes" and "No" buttons here will be replaced -->
         <%= link_to "Yes", "#", class:"btn btn-primary m-2" %>

--- a/app/views/instances/_show_waiting.erb
+++ b/app/views/instances/_show_waiting.erb
@@ -61,7 +61,8 @@
       <p>Instance pin: <%= instance.pin %></p>
     </div>
     <div class="col-12 justify-content-center text-center py-3">
-      <%= simple_form_for [@instance] do |f| %>
+      <% @round = Round.new %>
+      <%= simple_form_for([@instance, @round]) do |f| %>
         <!-- Implement logic/condition so than only Host should see/use this -->
         <%= f.submit "Start Game", class:"btn btn-primary w-75" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'games#index' # our landing page with selection of games
   resources :instances, only: [:create, :show, :update] do
-    resources :player_inputs, only: [:create, :index]
+    resources :rounds, only: [:create, :show] do
+      # resources :player_inputs, only: [:create]
+    end
   end
   resources :players, only: [:create]
 end

--- a/db/migrate/20220218095232_add_instance_reference_to_rounds.rb
+++ b/db/migrate/20220218095232_add_instance_reference_to_rounds.rb
@@ -1,0 +1,5 @@
+class AddInstanceReferenceToRounds < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :rounds, :instance, foreign_key: true
+  end
+end


### PR DESCRIPTION
I was working hard on the index of player_inputs for tomorrow but I figured it would be best to start implementing the round logic (otherwise it's way too complicated to keep track of the round number, game_content etc. etc. all within the player_inputs_controller) 

The two key changes:
- When someone taps the start button, the instance status is updated AND a round is created (later on we can add the same mechanism when the player taps on "next question") This all happens in the rounds_controller (unfortunately I don't think there is a way to trigger two methods, instances#update and rounds#create at the same time when a button is pressed)
- I added an instance_id to the round model - without that direct connection it gets too complicated to keep track of the round count. I think it's easier to retrieve all the rounds that belong to one instance, count them, then increment the count :)

And heeere is a video to show the code in action!

https://user-images.githubusercontent.com/68413600/154660884-4083e09d-33e1-4be2-b991-9abff9f50a5a.mov


