### PR TITLE
Auto refresh when other players joined the lobby

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,9 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = env['warden'].user || reject_unauthorized_connection
+    end
   end
 end

--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -44,8 +44,10 @@ class InstancesController < ApplicationController
     if @instance.save
       InstanceChannel.broadcast_to(
         @instance,
-        render_to_string(partial: "instances/show_question", locals: { game: @game })
-      )
+        { 
+          question_page: render_to_string(
+            partial: "instances/show_question", locals: { game: @game })
+        })
     end
   end
 end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -7,15 +7,17 @@ class PlayersController < ApplicationController
       redirect_to root_path, notice: "Lobby not found"
     else
       # Avoid dupplicate player
-      player = Player.where(user_id: current_user.id, instance_id: @instance.id)
-      if player.blank?
-        Player.create!(
+      # search_player = Player.where(user_id: current_user.id, instance_id: @instance.id)
+      # if search_player.blank?
+        new_player = Player.new(
           user_id: current_user.id,
           instance_id: @instance.id
         )
-      end
+        if new_player.save
+          user = User.find(new_player.user_id).nickname
+          InstanceChannel.broadcast_to( @instance, { player_list: user, player_count: @instance.players.count } )
+        end
       redirect_to instance_path(@instance)
     end
-
   end
 end

--- a/app/javascript/channels/instance_channel.js
+++ b/app/javascript/channels/instance_channel.js
@@ -1,9 +1,16 @@
 import consumer from "./consumer";
 
 const initInstanceChannel = () => {
+
   const instanceContainer = document.getElementById("instance")
+  // if (instanceContainer === null){
+  //   consumer.subscriptions.remove({ channel: "InstanceChannel" })
+  //   console.log("unsub")
+  // }
 
   if (instanceContainer) {
+    const playerCount = document.getElementById("player-count")
+    const playerList = document.getElementById("player-list")
     const instance_id = instanceContainer.dataset.instanceId;
     const host_id = instanceContainer.dataset.hostId;
     const host_name = instanceContainer.dataset.hostName;
@@ -16,13 +23,25 @@ const initInstanceChannel = () => {
       },
 
       disconnected() {
-        console.log("InstanceChannel disconnected");
-        `${player_name} has left the Instance Channel ${instance_id}`
+        console.log(`${player_name} has left the Instance Channel ${instance_id}`);
       },
 
       received(data) {
         console.log("InstanceChannel received", data);
-        instanceContainer.innerHTML = data;
+        const notice = `<div class="alert alert-success alert-dismissible fade show" role="alert">
+                        <strong>${data.player_list}</strong> has joined the lobby <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span></button></div>`
+        if (data.player_list){
+          playerList.insertAdjacentHTML(
+            "beforeend", 
+            `<div class="card shadow-sm p-3 bg-white rounded">${data.player_list}</div>`
+            )
+          playerCount.innerHTML = data.player_count
+            instanceContainer.insertAdjacentHTML("beforebegin", notice)
+        }
+        if (data.question_page){
+          instanceContainer.innerHTML = data.question_page;
+        }
       }
     });
   }

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,7 @@
 class Player < ApplicationRecord
   belongs_to :user
   belongs_to :instance
-  has_many :player_inputs
+  has_many :player_inputs, dependent: :destroy
+
+  validates :user_id, uniqueness: { scope: :instance_id }
 end

--- a/app/views/instances/_player_count.html.erb
+++ b/app/views/instances/_player_count.html.erb
@@ -1,0 +1,5 @@
+<h5>Players:</h5>
+<div class="d-flex">
+  <div id="player-count"><%= players.count %></div>
+  <div>/10</div> <!-- Max players is hardcoded for now -->
+</div>

--- a/app/views/instances/_player_list.html.erb
+++ b/app/views/instances/_player_list.html.erb
@@ -1,0 +1,6 @@
+<% players.each do |player| %>
+    <% user = User.find(player.user_id)%>
+    <div class="card my-2 shadow-sm p-3 bg-light rounded">
+        <%= user.nickname%>
+    </div>
+<% end %>

--- a/app/views/instances/_show_waiting.erb
+++ b/app/views/instances/_show_waiting.erb
@@ -3,18 +3,13 @@
   <div class="row justify-content-around">
     <div class="col-lg-6 col-md-4 col-sm-6 p-3 bg-white" style="border-bottom: 3px solid #F4F4F4; height: 360px; overflow: auto;">
       <div class="d-flex justify-content-between">
-        <h5>Players:</h5>
-        <p>0 / 5</p> <!--number of players here -->
+          <%= render  "player_count", players: players %> <!--number of players here -->
       </div>
-        <% players.each do |player| %>
-          <% user = User.find(player.user_id)%>
-          <div class>
-            <div class="card shadow-sm p-3 bg-white rounded">
-              <%= user.nickname%>
-            </div>
-          </div>
-        <% end %>
+      <div id="player-list">
+          <%= render "player_list", players: players %>
+      </div>
     </div>
+
 
     <div class="col-lg-6 col-md-4 col-sm-6 bg-white p-3" style="height: fit-content">
     <!-- Game Settings, select dropdowns are hardcoded for now -->
@@ -58,7 +53,10 @@
         </div>
 
       </div>
-      <p>Instance pin: <%= instance.pin %></p>
+      <div class="d-flex justify-content-between">
+        <p>Instance pin:</p>
+        <%= instance.pin %>
+      </div>
     </div>
     <div class="col-12 justify-content-center text-center py-3">
       <%= simple_form_for [@instance] do |f| %>


### PR DESCRIPTION
First of all I would like to apologize to @spioupiou, I removed your logic in avoiding duplicate players, Instead, I added validation on the players model 🙏  #broadcast_to doesn't seem to work on that particular logic and I don't know why. 

I can't seem to share my whole screen, so you can only see the host side, I Joined the lobby in the background


https://user-images.githubusercontent.com/79787121/154673089-b365cf89-ba45-4c77-b83d-8a6d7299bb98.mp4

We also need to somehow "destroy" the players when they are not in the instance lobby anymore, I will see what I can do about that

