### PR TITLE
prevent players from joining if instance has already started or done

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -6,6 +6,10 @@ class PlayersController < ApplicationController
 
     if @instance.blank?
       redirect_to root_path, alert: "Lobby not found"
+    elsif @instance.status == 'ongoing'
+      redirect_to root_path, alert: "Game already started, try not to miss the next one."
+    elsif @instance.status == 'done'
+      redirect_to root_path, alert: "Game already finihsed, join the next one."
     else
       new_player = Player.new(
         user: current_user,

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -9,7 +9,7 @@ class PlayersController < ApplicationController
     elsif @instance.status == 'ongoing'
       redirect_to root_path, alert: "Game already started, try not to miss the next one."
     elsif @instance.status == 'done'
-      redirect_to root_path, alert: "Game already finihsed, join the next one."
+      redirect_to root_path, alert: "Game already finished, join the next one."
     else
       new_player = Player.new(
         user: current_user,


### PR DESCRIPTION
This may cause problems in the future if we're in the middle of demo and when someone from the crowd attempts to join.