### PR TITLE
End game redirect to new instance

### DIFF
--- a/app/controllers/player_inputs_controller.rb
+++ b/app/controllers/player_inputs_controller.rb
@@ -2,14 +2,17 @@ class PlayerInputsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def create
-    # When user clicks on True or False button, an input is created
+    # player_inputs are created after players clicks on their answers from rounds show page phase1
+
     @instance = Instance.find(params[:instance_id])
+    @current_user = current_or_guest_user
     @round = Round.find(params[:round_id])
+    # for end game redirection to new instance: find player ids except host
+    @non_host_player_user_ids = @instance.non_host_player_user_ids
 
     # Change to phase 2 (collecting users' results)
-    @round.phase = 2
-    @round.save
-    @current_user = current_or_guest_user
+    # line only gets executed after any player submits the first input
+    @round.update(phase: 2) if @round.phase == 1
 
     @player_input = PlayerInput.create!(
       instance_id: @instance.id,

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -47,5 +47,7 @@ class RoundsController < ApplicationController
     @round = Round.find(params[:id])
     @game_content = GameContent.find(@round.game_content_id)
     @player_inputs = PlayerInput.where(round_id: @round.id)
+    # non_host_player_user_ids is an instace model method retrieving user_id of non-host players
+    @non_host_player_user_ids = @instance.non_host_player_user_ids
   end
 end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -9,4 +9,12 @@ class Instance < ApplicationRecord
   validates :max_players, presence:true, numericality: { greater_than_or_equal_to: 2 }
 
   enum status: { waiting: 'waiting', ongoing: 'ongoing', done: 'done' }
+
+  # find user_ids of all players in the instance except for host
+  def non_host_player_user_ids
+    players = Player.where(instance: self).order(id: :desc) # find all players
+    user_ids = players.map(&:user_id)                       # find all player.user_id
+    user_ids.delete(self.user_id)                           # remove host's user_id
+    user_ids                                                # return array of user_id w/o host's user_id
+  end
 end

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -23,18 +23,21 @@
 
     <% if @current_user.id == @instance.user_id %>
       <div class="row justify-content-center" id="host-buttons">
-        <%@new_round = Round.new %>
-        <%= simple_form_for([@instance, @new_round]) do |f| %>
+        <%= simple_form_for([@instance, Round.new]) do |f| %>
           <div class="col-6">
             <%= hidden_field_tag 'current_round', @round.id %>
             <%= f.submit "Continue", class:"btn btn-primary" %>
           </div>
         <% end %>
 
-        <%= link_to instances_path(game_id: @game_id), method: :post do %>
-          <div class="col-12">
-            <p class="btn btn-warning">Exit Game</p>
-          </div>
+        <%= simple_form_for Instance.new do |f| %>
+          <%# needed for creating a new instance %>
+          <%= hidden_field_tag 'game_id', @game_id %>
+          <%# needed to broadcast the redirect %>
+          <%= hidden_field_tag 'round_id', @round.id %>
+          <%# needed for creating players in the new instance, gives us a string of user ids like so "8 9 10 22" %>
+          <%= hidden_field_tag :concatenated_user_ids, @non_host_player_user_ids %>
+          <%= f.submit "Exit Game", class: "btn btn-warning" %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
We can now exit the game and bring all users that are in the results page to the newly created instance.

https://user-images.githubusercontent.com/18746187/155277909-df9e3238-b26e-454b-b6ce-30e043a14672.mov

In the future, we may want to disable the buttons until all players are in the results page so no players gets left behind
- when transitioning to the next question
- when transitioning to the new game