### PR TITLE
No more duplicate questions

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -59,11 +59,10 @@ class RoundsController < ApplicationController
     game_contents_array = game.game_contents
 
     loop do
-      game_contents_array = Game.game_contents if game_contents_array.empty?
       round.game_content_id = game_contents_array.sample.id
       break if round.valid?
     end
 
-    return round
+    round
   end
 end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -16,13 +16,17 @@ class RoundsController < ApplicationController
       @instance.save
     end
 
-    @game_content = GameContent.all.sample
     rounds = Round.where(instance_id: @instance.id)
     @round = Round.new(
       number: rounds.count + 1,
-      game_content_id: @game_content.id,
       instance_id: @instance.id
     )
+
+    loop do
+      game_content = GameContent.all.sample
+      @round.game_content_id = game_content.id
+      break if @round.valid?
+    end
 
     if @round.save
       # redirect all subscribers except host to rounds phase1

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -55,9 +55,15 @@ class RoundsController < ApplicationController
   def generate_unique_question(instance, round)
     game = Game.find(instance.game_id)
     game_contents_array = game.game_contents
+    game_contents_ids = game_contents_array.map(&:id)
 
     loop do
-      round.game_content_id = game_contents_array.sample.id
+      if game_contents_array.empty?
+        game_contents_array = game.game_contents
+        game_contents_ids = game_contents_array.map(&:id)
+      end
+
+      round.game_content_id = game_contents_ids.shuffle!.pop
       break if round.valid?
     end
 

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -22,11 +22,7 @@ class RoundsController < ApplicationController
       instance_id: @instance.id
     )
 
-    loop do
-      game_content = GameContent.all.sample
-      @round.game_content_id = game_content.id
-      break if @round.valid?
-    end
+    @round = generate_unique_question(@instance, @round)
 
     if @round.save
       # redirect all subscribers except host to rounds phase1
@@ -52,7 +48,22 @@ class RoundsController < ApplicationController
     @round = Round.find(params[:id])
     @game_content = GameContent.find(@round.game_content_id)
     @player_inputs = PlayerInput.where(round_id: @round.id)
-    # non_host_player_user_ids is an instace model method retrieving user_id of non-host players
+    # non_host_player_user_ids is an instance model method retrieving user_id of non-host players
     @non_host_player_user_ids = @instance.non_host_player_user_ids
+  end
+
+  private
+
+  def generate_unique_question(instance, round)
+    game = Game.find(instance.game_id)
+    game_contents_array = game.game_contents
+
+    loop do
+      game_contents_array = Game.game_contents if game_contents_array.empty?
+      round.game_content_id = game_contents_array.sample.id
+      break if round.valid?
+    end
+
+    return round
   end
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -4,4 +4,5 @@ class Round < ApplicationRecord
 
   # numericality is to only accept positive values
   validates :number, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :game_content_id, uniqueness: { scope: :instance_id }
 end


### PR DESCRIPTION
I completely forgot this afternoon that we already have a model which contains both the game_content_id and the instance_id: that's the round!!
So I just added a validation to the round model, the combination of game_content_id and instance_id must be unique.
Then in the controller I sample the game_contents until it finds a unique question that hasn't been used in the instance yet (highly inspired by @carlnoval do-break loop for passcode, thank you for the inspiration!)

Please test it out! (And please be careful because right now we only have 17 seeds, so if you set more than 17 rounds for your game, rails will try to find a unique question and loop indefinitely. Tested by yours truly 🤣 )

![Screen Shot 2022-02-26 at 22 06 08](https://user-images.githubusercontent.com/68413600/155844631-7c0c8185-621b-4e4c-8ce9-68d7b659f3eb.png)

