### PR TITLE
Vote model

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,5 @@
+class Vote < ApplicationRecord
+  belongs_to :instance
+  belongs_to :voter, class_name: 'Player'
+  belongs_to :voted_player, class_name: 'Player'
+end

--- a/db/migrate/20220301141726_create_votes.rb
+++ b/db/migrate/20220301141726_create_votes.rb
@@ -1,0 +1,14 @@
+class CreateVotes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :votes do |t|
+      t.references :instance, null: false, foreign_key: true
+      t.references :voter, null: false
+      t.references :voted_player, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :votes, :players, column: :voter_id
+    add_foreign_key :votes, :players, column: :voted_player_id
+  end
+end

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class VoteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Migration for the vote model!
Voter and voted_player both reference the players table, I followed the below tutorial:
https://dev.to/luchiago/multiple-foreign-keys-for-the-same-model-in-rails-6-7ml