### PR TITLE
Functional twitter button that share current URL

### DIFF
--- a/app/javascript/components/screenshot.js
+++ b/app/javascript/components/screenshot.js
@@ -2,7 +2,7 @@ import Rails from "@rails/ujs";
 import html2canvas from 'html2canvas';
 
 
-const captureResults = () => {
+const downloadResults = () => {
   const results = document.querySelector("#result");
   const saveBtn = document.querySelector("#download");
 
@@ -32,7 +32,7 @@ const captureResults = () => {
       //   document.getElementById("screenshot").src = image;
       // }
 
-      // Find a way to save in base64 image
+      // Save in base64 image
       let file = dataURLtoBlob(image)
 
       let fd = new FormData();
@@ -42,7 +42,6 @@ const captureResults = () => {
       // Append the result number to the form data
       let url = window.location.href;
       const resultId = url.split("/").pop();
-      console.log(resultId);
       fd.append("result", resultId)
 
       // And send it
@@ -63,9 +62,59 @@ const captureResults = () => {
   }
 
   if (!!saveBtn) {
-    console.log(saveBtn)
     saveBtn.addEventListener('click', takeScreenshot)
   }
 }
 
-export { captureResults }
+const tweetResults = () => {
+  const results = document.querySelector('#result');
+  const title = results.querySelector('h1');
+  let twitterBtn = document.querySelector('#twitter');
+
+  const currentPageUrl = window.location.href;
+
+  const makeTweetableUrl = (text, pageUrl) => {
+    const tweetableText = "https://twitter.com/intent/tweet?url=" + pageUrl + "&text=" + encodeURIComponent(text);
+    return tweetableText;
+  }
+
+  if (!!twitterBtn) {
+    let tweetableUrl = makeTweetableUrl(title.innerText, currentPageUrl);
+    twitterBtn.setAttribute("href", tweetableUrl);
+
+    // Open the popup
+    $(twitterBtn).click(function (e) {
+      e.preventDefault();
+      var href = $(this).attr('href');
+      window.open(href, "Twitter", "height=400,width=300,resizable=1");
+    });
+  }
+}
+
+const fbResults = () => {
+  const results = document.querySelector('#result');
+  const title = results.querySelector('h1');
+  let twitterBtn = document.querySelector('#twitter');
+
+  const currentPageUrl = window.location.href;
+
+  const makeTweetableUrl = (text, pageUrl) => {
+    const tweetableText = "https://twitter.com/intent/tweet?url=" + pageUrl + "&text=" + encodeURIComponent(text);
+    return tweetableText;
+  }
+
+  if (!!twitterBtn) {
+    let tweetableUrl = makeTweetableUrl(title.innerText, currentPageUrl);
+    twitterBtn.setAttribute("href", tweetableUrl);
+
+    // Open the popup
+    $(twitterBtn).click(function (e) {
+      e.preventDefault();
+      var href = $(this).attr('href');
+      window.open(href, "Twitter", "height=400,width=300,resizable=1");
+    });
+  }
+}
+
+export { downloadResults };
+export { tweetResults };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -35,13 +35,14 @@ import { countdownTimer } from "../components/countdown_timer";
 import { autoFocus } from "../components/auto_focus";
 import { updateDiv } from "../components/auto_refresh";
 import { initResultCable } from "../channels/result_channel";
+import { downloadResults } from "../components/screenshot";
+import { tweetResults } from "../components/screenshot";
 
 
 // next 3 lines is from https://fontsource.org/fonts
 import "@fontsource/roboto";
 import "@fontsource/play";
 import "@fontsource/dosis";
-import { captureResults } from "../components/screenshot";
 
 document.addEventListener('turbolinks:load', () => {
 
@@ -53,5 +54,7 @@ document.addEventListener('turbolinks:load', () => {
   countdownTimer();
   autoFocus();
   updateDiv();
-  captureResults();
+  downloadResults();
+  tweetResults();
+
 });

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -37,7 +37,7 @@
         <!-- Partial for SNS -->
         <div class="sns-icons d-flex justify-content-center my-2">
           <i class="fb_with_bg fab fa-facebook-square" id="facebook"></i>
-          <i class="fa_with_bg fab fa-twitter-square" id="twitter"></i>
+          <a href="" id="twitter"><i class="fa_with_bg fab fa-twitter-square"></i></a>
           <i class="fa_with_bg fab fa-instagram-square" id="instagram"></i>
           <i class="fa_with_bg fas fa-caret-square-down" id="download"></i>
         </div>


### PR DESCRIPTION
Simple PR so that when the user clicks on the twitter button, a popup opens and he can tweet the current results page url :) 

I will talk to a teacher tonight to find out the best way to share the screenshot to social media (and also to minify the URL) 

The issue right now is:
-- We can't really use the Rails helpers to change the meta-tags as we are taking the screenshot after the page is loaded
-- We can't dynamically change the meta tags with javascript as this only happens on client's side 

Maybe the only way might be to upload the screenshot on cloudinary and then share the link in the tweet (this also might be tough to do because I am not sure how to retrieve the url of the screenshot to share it on twitter, in javascript we can't really have a @result.image 😭  Anyway at least the twitter button shares the current result url as a bare minimum!)